### PR TITLE
enhance: specify health as system requirement

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -7,6 +7,7 @@
       <Description>Application for InterSystems FHIR and Digital Health Interoperability Contest</Description>
       <Keywords>FHIR</Keywords>
       <Packaging>module</Packaging>
+      <SystemRequirements Interoperability="enabled" Health="true"/>
       <SourcesRoot>src</SourcesRoot>
       <FileCopy Name="data/fhir/" Target="${mgrdir}dataFhir/"/>
       <Invokes>


### PR DESCRIPTION
Hi there, 

InterSystems is rolling out a [newer version](https://github.com/intersystems/ipm/tree/v1) of package manager that allows package contributors to declare their package requires healthcare/healthconnect/iris for health. With this change, a user will get a descriptive warning:
```
ERROR! The module requires InterSystems IRIS for Health, HealthConnect, or HealthShare. Current system is not compatible.
```
when trying to install the package on incompatible systems with the new package manager.

This change is also backward compatible.